### PR TITLE
Set scale to 0 for bc explicitly.

### DIFF
--- a/bin/battery
+++ b/bin/battery
@@ -25,7 +25,7 @@ linux_get_bat ()
 {
     bf=$(cat $BAT_FULL)
     bn=$(cat $BAT_NOW)
-    BAT=`echo "100 * $bn / $bf" | bc`
+    BAT=`echo "scale=0; 100 * $bn / $bf" | bc`
     echo $BAT
 }
 


### PR DESCRIPTION
I have my own .bc config file with scale=2 (useful when I'm doing some adhoc calculations) but I don't want my scale to affect this battery calculation.
